### PR TITLE
Refactor Automoderation Link Regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ bugfix/bug-name
 ![](https://img.shields.io/badge/contributions-welcome-red)
 
 ![](https://img.shields.io/badge/Rohan%20Gupta-rohangupta%238570-lightgreen)
-
 ![](https://img.shields.io/badge/Daryl%20Damman-brandt.damman%40spudwilson.us-blue)
 
 <br>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ bugfix/bug-name
 
 ![](https://img.shields.io/badge/Rohan%20Gupta-rohangupta%238570-lightgreen)
 
+![](https://img.shields.io/badge/Daryl%20Damman-brandt.damman%40spudwilson.us-blue)
+
 <br>
 
 # Online College

--- a/dependencies/automod.js
+++ b/dependencies/automod.js
@@ -58,7 +58,7 @@ module.exports = {
 
 		function links(message) {
 			// regex to match general links
-			const linkRegex = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/;
+			const linkRegex = /^(https?:\/\/)?(www\.)?(?!((?:www\.|)tenor\.(com)))[\p{L}\-0-9]{2,}\.[^\s]{2,}/;
 
 			let sentLink = message.content.slice(message.content.search(linkRegex)).split(/ +/)[0];
 

--- a/dependencies/automod.js
+++ b/dependencies/automod.js
@@ -66,7 +66,7 @@ module.exports = {
 			const daysOnServer = Math.floor((Date.now() - message.member.joinedTimestamp) / 86400000);
 
 			const linkBlacklistTime = 7; // number of days before you can post links on the server
-			if (message.content.search(linkRegex) != -1 && daysOnServer < linkBlacklistTime) {
+			if (daysOnServer < linkBlacklistTime && message.content.search(linkRegex) != -1) {
 				// create embed base
 				const linkTester = new MessageEmbed()
 					.setColor(`E22E2E`) // RED


### PR DESCRIPTION
The original `linkRegex` used in `automod.js` completely prohibited all links.  This prohibition included GIF images from Tenor found via Discord's built-in search.  To promote Good UX Practices<sup>TM</sup>, a new regular expression was written to allow Tenor links to not be matched by the regular expression and thus not trigger the auto-mod.

As of writing, no comprehensive analysis of the regular expression was done with [RAGEL](http://www.colm.net/open-source/ragel/) to confirm that the new regular expression matches all the same hyperlinks.  In place of RAGEL, numerous hyperlinks were generated and thrown against the regular expression with mixed-in Tenor links to confirm appropriate matching and non-matching results.